### PR TITLE
Readme fix: name of openframe property

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ There are some properties you can pass to ```glslGallery``` through the ```data-
 |```showAuthor```| ```true``` or ```false``` | ```true``` |
 |```showTitle```| ```true``` or ```false``` | ```true``` |
 |```hoverPreview```| ```true``` or ```false``` | ```true``` |
-|```openframe```| ```true``` or ```false``` | ```true``` |
+|```openFrameIcon```| ```true``` or ```false``` | ```true``` |
 |```logs```| *string* or *array* | ```null``` |
 
 For example you can do:


### PR DESCRIPTION
This PR changes the README to name the correct property that needs to be toggled when turning off the OpenFrame icon: `openFrameIcon`. Previously it was `openframe`, which was wrong.

Cheers